### PR TITLE
MNT: Add Stefan and Ansgar as maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @matthewfeickert
+* @ansgardenner @dittmaier @matthewfeickert

--- a/README.md
+++ b/README.md
@@ -213,5 +213,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@ansgardenner](https://github.com/ansgardenner/)
+* [@dittmaier](https://github.com/dittmaier/)
 * [@matthewfeickert](https://github.com/matthewfeickert/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,3 +76,5 @@ about:
 extra:
   recipe-maintainers:
     - matthewfeickert
+    - ansgardenner
+    - dittmaier


### PR DESCRIPTION
* Add Stefan Dittmaier and Ansgar Denner as maintainers.
* Not bumping the build number as only the metadata has changed.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
