### PR TITLE
MNT: Test for file presence in package correctly

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -3,7 +3,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -21,7 +21,5 @@ fortran_compiler_version:
 target_platform:
 - linux-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - cxx_compiler_version
   - fortran_compiler_version

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -7,7 +7,7 @@ c_stdlib_version:
 cdt_arch:
 - aarch64
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -25,7 +25,5 @@ fortran_compiler_version:
 target_platform:
 - linux-aarch64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - cxx_compiler_version
   - fortran_compiler_version

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -3,7 +3,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -21,7 +21,5 @@ fortran_compiler_version:
 target_platform:
 - linux-ppc64le
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - cxx_compiler_version
   - fortran_compiler_version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
   commands:
     - test -f $PREFIX/lib/cmake/collierConfig.cmake
     - test -f $PREFIX/lib/cmake/collierConfigVersion.cmake
-    - test -f $PREFIX/lib/libcollier.so
+    - test -f $PREFIX/lib/libcollier${SHLIB_EXT}
     - test -f $PREFIX/include/collier.mod
 
     - cd source/demos

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('collier', max_pin='x.x') }}
   script:
@@ -30,16 +30,16 @@ requirements:
     - make
 
 test:
-  files:
-    - $PREFIX/lib/cmake/collierConfig.cmake
-    - $PREFIX/lib/cmake/collierConfigVersion.cmake
-    - $PREFIX/lib/libcollier.so
-    - $PREFIX/include/collier.mod
   source_files:
     - source/demos
   requires:
     - {{ compiler('fortran') }}
   commands:
+    - test -f $PREFIX/lib/cmake/collierConfig.cmake
+    - test -f $PREFIX/lib/cmake/collierConfigVersion.cmake
+    - test -f $PREFIX/lib/libcollier.so
+    - test -f $PREFIX/include/collier.mod
+
     - cd source/demos
     - $FC demo.f90 -o demo -I$PREFIX/include -lcollier
     - $FC democache.f90 -o democache -I$PREFIX/include -lcollier


### PR DESCRIPTION
* The 'files' section defines files to copy from the build recipe into a temporary test directory. The more correct way to test for the existence of files in a package is by using the 'test -f' command.
   - c.f. https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#test-files
   - c.f. https://github.com/conda-forge/staged-recipes/pull/28224#discussion_r1848633827
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
