### PR TITLE
MNT: Ignore cxx compiler run exports

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,15 +11,15 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/build-locally.py
+++ b/build-locally.py
@@ -26,6 +26,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,8 +43,10 @@ test:
     - test -f $PREFIX/include/collier.mod
 
     - cd source/demos
-    - $FC demo.f90 -o demo $FFLAGS -lcollier
-    - $FC democache.f90 -o democache $FFLAGS -lcollier
+    - $FC demo.f90 -o demo $FFLAGS -lcollier  # [not (osx and x86)]
+    - $FC demo.f90 -o demo $FFLAGS -I$PREFIX/include -lcollier  # [osx and x86]
+    - $FC democache.f90 -o democache $FFLAGS -lcollier  # [not (osx and x86)]
+    - $FC democache.f90 -o democache $FFLAGS -I$PREFIX/include -lcollier  # [osx and x86]
     - ./democache  # [build_platform == target_platform]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,11 @@ source:
 
 build:
   skip: true  # [win]
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage('collier', max_pin='x.x') }}
+  ignore_run_exports_from:
+    - {{ compiler('cxx') }}
   script:
     - cmake -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_Fortran_COMPILER=$FC -S source -B build
     - cmake -LH build
@@ -41,8 +43,8 @@ test:
     - test -f $PREFIX/include/collier.mod
 
     - cd source/demos
-    - $FC demo.f90 -o demo -I$PREFIX/include -lcollier
-    - $FC democache.f90 -o democache -I$PREFIX/include -lcollier
+    - $FC demo.f90 -o demo $FFLAGS -lcollier
+    - $FC democache.f90 -o democache $FFLAGS -lcollier
     - ./democache  # [build_platform == target_platform]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,8 @@ test:
 
     - cd source/demos
     # The addition of -I$PREFIX/include is only needed on osx, but for
-    # simplicity add it for all
+    # simplicity add it for all.
+    # demo executable requires user keyboard input, so skip after build.
     - $FC demo.f90 -o demo $FFLAGS -I$PREFIX/include -lcollier
     - $FC democache.f90 -o democache $FFLAGS -I$PREFIX/include -lcollier
     - ./democache  # [build_platform == target_platform]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,10 @@ build:
     - {{ pin_subpackage('collier', max_pin='x.x') }}
   ignore_run_exports_from:
     - {{ compiler('cxx') }}
+    - sed
   script:
+    # Use modern CMake by using range of compatible versions
+    - sed -i 's/cmake_minimum_required (VERSION 2.8.7)/cmake_minimum_required(VERSION 3.15...3.31)/g' source/CMakeLists.txt
     - cmake -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_Fortran_COMPILER=$FC -S source -B build
     - cmake -LH build
     - cmake --build build --clean-first --parallel="${CPU_COUNT}"
@@ -30,6 +33,7 @@ requirements:
     - {{ compiler('fortran') }}
     - cmake
     - make
+    - sed
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,9 +43,10 @@ test:
     - test -f $PREFIX/include/collier.mod
 
     - cd source/demos
-    - export FFLAGS="$FFLAGS -I$PREFIX/include"  # [osx and x86]
-    - $FC demo.f90 -o demo $FFLAGS -lcollier
-    - $FC democache.f90 -o democache $FFLAGS -lcollier
+    # The addition of -I$PREFIX/include is only needed on osx, but for
+    # simplicity add it for all
+    - $FC demo.f90 -o demo $FFLAGS -I$PREFIX/include -lcollier
+    - $FC democache.f90 -o democache $FFLAGS -I$PREFIX/include -lcollier
     - ./democache  # [build_platform == target_platform]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,10 +43,9 @@ test:
     - test -f $PREFIX/include/collier.mod
 
     - cd source/demos
-    - $FC demo.f90 -o demo $FFLAGS -lcollier  # [not (osx and x86)]
-    - $FC demo.f90 -o demo $FFLAGS -I$PREFIX/include -lcollier  # [osx and x86]
-    - $FC democache.f90 -o democache $FFLAGS -lcollier  # [not (osx and x86)]
-    - $FC democache.f90 -o democache $FFLAGS -I$PREFIX/include -lcollier  # [osx and x86]
+    - export FFLAGS="$FFLAGS -I$PREFIX/include"  # [osx and x86]
+    - $FC demo.f90 -o demo $FFLAGS -lcollier
+    - $FC democache.f90 -o democache $FFLAGS -lcollier
     - ./democache  # [build_platform == target_platform]
 
 about:


### PR DESCRIPTION
* Use ignore_run_exports_from to ignore the run exports from the required cxx compiler for CMake to not complain.
   - c.f. https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#export-runtime-requirements

* Use `sed` to update the `CMakeLists.txt` to have a range of compatible CMake versions, which allows for modern CMake to be used.
   - Use sed as not a source controlled repository, so can't apply Git patches.
   - Add `sed` to `ignore_run_exports_from` so that it is only a build tool.
   - CMake v3.15 is where range support was added.
* Add note that macOS requires adding '-I$PREFIX/include' in addition to '$FFLAGS'.

* Use FFLAGS over explicit -I include paths.
* Bump build number.

```
* Use ignore_run_exports_from to ignore the run exports from the required
  cxx compiler for CMake to not complain.
   - c.f. https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#export-runtime-requirements
* Use sed to update the CMakeLists.txt to have a range of compatible CMake versions,
  which allows for modern CMake to be used.
   - Use sed as not a source controlled repository, so can't apply Git patches.
   - Add `sed` to `ignore_run_exports_from` so that it is only a build tool.
   - CMake v3.15 is where range support was added.
* Add note that macOS requires adding '-I$PREFIX/include' in addition to '$FFLAGS'.
* Bump build number.
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
