### PR TITLE
ENH: Add static library output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-collier-green.svg)](https://anaconda.org/conda-forge/collier) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/collier.svg)](https://anaconda.org/conda-forge/collier) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/collier.svg)](https://anaconda.org/conda-forge/collier) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/collier.svg)](https://anaconda.org/conda-forge/collier) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-collier--static-green.svg)](https://anaconda.org/conda-forge/collier-static) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/collier-static.svg)](https://anaconda.org/conda-forge/collier-static) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/collier-static.svg)](https://anaconda.org/conda-forge/collier-static) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/collier-static.svg)](https://anaconda.org/conda-forge/collier-static) |
 
 Installing collier
 ==================
@@ -109,16 +110,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `collier` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `collier, collier-static` can be installed with `conda`:
 
 ```
-conda install collier
+conda install collier collier-static
 ```
 
 or with `mamba`:
 
 ```
-mamba install collier
+mamba install collier collier-static
 ```
 
 It is possible to list all of the versions of `collier` available on your platform with `conda`:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,9 @@
 {% set version = "1.2.8" %}
 
 package:
-  name: {{ name }}
+  # Have top level name be unique from any outputs
+  # c.f. https://github.com/conda-forge/conda-forge.github.io/blob/abfc33db28c35e9a8f6b719d0021768f0d5d06be/docs/maintainer/knowledge_base.md?plain=1#L1749
+  name: {{ name }}-split
   version: {{ version }}
 
 source:
@@ -11,48 +13,98 @@ source:
   folder: source
 
 build:
-  skip: true  # [win]
-  number: 4
-  run_exports:
-    - {{ pin_subpackage('collier', max_pin='x.x') }}
-  ignore_run_exports_from:
-    - {{ compiler('cxx') }}
-    - sed
-  script:
-    # Use modern CMake by using range of compatible versions
-    - sed -i 's/cmake_minimum_required (VERSION 2.8.7)/cmake_minimum_required(VERSION 3.15...3.31)/g' source/CMakeLists.txt
-    - cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_Fortran_COMPILER=$FC -S source -B build
-    - cmake -LH build
-    - cmake --build build --clean-first --parallel="${CPU_COUNT}"
-    - cmake --install build
+  number: 5
 
-requirements:
-  build:
-    - {{ stdlib('c') }}
-    - {{ compiler('cxx') }}  # Not used, but needed for CMake to not error
-    - {{ compiler('fortran') }}
-    - cmake
-    - make
-    - sed
+outputs:
+  - name: {{ name }}
 
-test:
-  source_files:
-    - source/demos
-  requires:
-    - {{ compiler('fortran') }}
-  commands:
-    - test -f $PREFIX/lib/cmake/collierConfig.cmake
-    - test -f $PREFIX/lib/cmake/collierConfigVersion.cmake
-    - test -f $PREFIX/lib/libcollier${SHLIB_EXT}
-    - test -f $PREFIX/include/collier.mod
+    build:
+      skip: true  # [win]
+      run_exports:
+        - {{ pin_subpackage('collier', max_pin='x.x') }}
+      ignore_run_exports_from:
+        - {{ compiler('cxx') }}
+        - sed
+      script:
+        # Use modern CMake by using range of compatible versions
+        - sed -i 's/cmake_minimum_required (VERSION 2.8.7)/cmake_minimum_required(VERSION 3.15...3.31)/g' source/CMakeLists.txt
+        - cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_Fortran_COMPILER=$FC -S source -B build
+        - cmake -LH build
+        - cmake --build build --clean-first --parallel="${CPU_COUNT}"
+        - cmake --install build
 
-    - cd source/demos
-    # The addition of -I$PREFIX/include is only needed on osx, but for
-    # simplicity add it for all.
-    # demo executable requires user keyboard input, so skip after build.
-    - $FC demo.f90 -o demo $FFLAGS -I$PREFIX/include -lcollier
-    - $FC democache.f90 -o democache $FFLAGS -I$PREFIX/include -lcollier
-    - ./democache  # [build_platform == target_platform]
+    requirements:
+      build:
+        - {{ stdlib('c') }}
+        - {{ compiler('cxx') }}  # Not used, but needed for CMake to not error
+        - {{ compiler('fortran') }}
+        - cmake
+        - make
+        - sed
+
+    test:
+      source_files:
+        - source/demos
+      requires:
+        - {{ compiler('fortran') }}
+      commands:
+        - test -f $PREFIX/lib/cmake/collierConfig.cmake
+        - test -f $PREFIX/lib/cmake/collierConfigVersion.cmake
+        - test -f $PREFIX/lib/libcollier${SHLIB_EXT}
+        - test ! -f $PREFIX/lib/libcollier.a
+        - test -f $PREFIX/include/collier.mod
+
+        - cd source/demos
+        # The addition of -I$PREFIX/include is only needed on osx, but for
+        # simplicity add it for all.
+        # demo executable requires user keyboard input, so skip after build.
+        - $FC demo.f90 -o demo $FFLAGS -I$PREFIX/include -lcollier
+        - $FC democache.f90 -o democache $FFLAGS -I$PREFIX/include -lcollier
+        - ./democache  # [build_platform == target_platform]
+
+  - name: {{ name }}-static
+
+    build:
+      skip: true  # [win]
+      ignore_run_exports_from:
+        - {{ compiler('cxx') }}
+        - sed
+      script:
+        # Use modern CMake by using range of compatible versions
+        - sed -i 's/cmake_minimum_required (VERSION 2.8.7)/cmake_minimum_required(VERSION 3.15...3.31)/g' source/CMakeLists.txt
+        - cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_Fortran_COMPILER=$FC -Dstatic=ON -S source -B build
+        - cmake -LH build
+        - cmake --build build --clean-first --parallel="${CPU_COUNT}"
+        - cmake --install build
+
+    requirements:
+      build:
+        - {{ stdlib('c') }}
+        - {{ compiler('cxx') }}  # Not used, but needed for CMake to not error
+        - {{ compiler('fortran') }}
+        - cmake
+        - make
+        - sed
+
+    test:
+      source_files:
+        - source/demos
+      requires:
+        - {{ compiler('fortran') }}
+      commands:
+        - test -f $PREFIX/lib/cmake/collierConfig.cmake
+        - test -f $PREFIX/lib/cmake/collierConfigVersion.cmake
+        - test -f $PREFIX/lib/libcollier.a
+        - test ! -f $PREFIX/lib/libcollier${SHLIB_EXT}
+        - test -f $PREFIX/include/collier.mod
+
+        - cd source/demos
+        # The addition of -I$PREFIX/include is only needed on osx, but for
+        # simplicity add it for all.
+        # demo executable requires user keyboard input, so skip after build.
+        - $FC demo.f90 -o demo $FFLAGS -I$PREFIX/include -lcollier
+        - $FC democache.f90 -o democache $FFLAGS -I$PREFIX/include -lcollier
+        - ./democache  # [build_platform == target_platform]
 
 about:
   home: https://collier.hepforge.org/
@@ -83,6 +135,7 @@ about:
   doc_url: https://collier.hepforge.org/documentation.html
 
 extra:
+  feedstock-name: collier
   recipe-maintainers:
     - matthewfeickert
     - ansgardenner

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,7 +72,7 @@ outputs:
       script:
         # Use modern CMake by using range of compatible versions
         - sed -i 's/cmake_minimum_required (VERSION 2.8.7)/cmake_minimum_required(VERSION 3.15...3.31)/g' source/CMakeLists.txt
-        - cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_Fortran_COMPILER=$FC -Dstatic=ON -S source -B build
+        - cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX -Dstatic=ON -DCMAKE_Fortran_COMPILER=$FC -S source -B build
         - cmake -LH build
         - cmake --build build --clean-first --parallel="${CPU_COUNT}"
         - cmake --install build


### PR DESCRIPTION
* Split package into collier and collier-static.
   - libcollier.a is required for use with mg5amcnlo.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
